### PR TITLE
Bump cortex-m and cortex-m-rt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,8 @@ name = "types"
 required-features = ["timer-queue"]
 
 [dependencies]
-cortex-m = "0.5.8"
-cortex-m-rt = "0.6.7"
+cortex-m = "0.6"
+cortex-m-rt = "0.6"
 cortex-m-rtfm-macros = { path = "macros", version = "0.5.0-alpha.1" }
 heapless = "0.5.0-alpha.1"
 


### PR DESCRIPTION
I'm not sure if there's a reason to stick with `cortex-m` 0.5?
It would be nice to depend on `0.x` versions to not have to bump this crate whenever improvements are made in `y` of `0.x.y`.
My use case is to enable LPC55S6x.