### PR TITLE
turn git deps into crates.io deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ required-features = ["__v7"]
 [dependencies]
 cortex-m = "0.6.0"
 cortex-m-rtfm-macros = { path = "macros" }
-rtfm-core = { git = "https://github.com/rtfm-rs/rtfm-core" }
+rtfm-core = "0.3.0-beta.1"
 cortex-m-rt = "0.6.9"
 heapless = "0.5.0"
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -18,9 +18,7 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = "1"
-
-[dependencies.rtfm-syntax]
-git = "https://github.com/rtfm-rs/rtfm-syntax"
+rtfm-syntax = "0.4.0-beta.1"
 
 [features]
 heterogeneous = []


### PR DESCRIPTION
required for publishing v0.5.0-beta