### PR TITLE
Fix matrix.to web link for the static room view.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ A concurrency framework for building real time systems.
 ## Chat
 Join us and talk about RTFM in the [Matrix room][matrix-room].
 
-[matrix-room]: https://matrix.to/#/!yafYEipFNsXDdwiHMT:matrix.org
+[matrix-room]: https://matrix.to/#/#rtfm-rs:matrix.org
 
 ## Contributing
 New features and big changes should go through the RFC process in the [dedicated RFC repository][rfcs].


### PR DESCRIPTION
Fix the matrix.to link so that the room history can be viewed in
"Matrix-Static" by users who aren't registered on Matrix (e.g. for
previewing).  Hopefully this will also get the room content into search
engines.

n.b. The new matrix.to URL uses the room name instead of the room ID,
because the ID didn't work with Matrix-Static, and the matrix.to README at:

https://github.com/matrix-org/matrix.to says...

"Note that linking to rooms by ID should only be used for rooms to which
the target user has been invited: these links cannot be assumed to work for
all visitors."