### PR TITLE
v0.5.0 beta release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - [breaking-change][] [RFC 155] "explicit `Context` parameter" has been
   implemented.
 
-[RFC 155]: https://github.com/japaric/cortex-m-rtfm/issues/155
+[RFC 155]: https://github.com/rtfm-rs/cortex-m-rtfm/issues/155
 
 - [breaking-change][] [RFC 147] "all functions must be safe" has been
   implemented.
 
-[RFC 147]: https://github.com/japaric/cortex-m-rtfm/issues/147
+[RFC 147]: https://github.com/rtfm-rs/cortex-m-rtfm/issues/147
 
 - All the queues internally used by the framework now use `AtomicU8` indices
   instead of `AtomicUsize`; this reduces the static memory used by the
@@ -67,7 +67,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   syntax. `init::LateResources` is the only method to initialize late resources.
   See [PR #140] for more details.
 
-[PR #140]: https://github.com/japaric/cortex-m-rtfm/pull/140
+[PR #140]: https://github.com/rtfm-rs/cortex-m-rtfm/pull/140
 
 ## [v0.4.3] - 2019-04-21
 
@@ -96,7 +96,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   `binds` argument that lets you give the handler an arbitrary name. For
   example:
 
-[RFC 128]: https://github.com/japaric/cortex-m-rtfm/issues/128
+[RFC 128]: https://github.com/rtfm-rs/cortex-m-rtfm/issues/128
 
 ``` rust
 // on v0.4.1 you had to write
@@ -295,17 +295,17 @@ Yanked due to a soundness issue in `init`; the issue has been mostly fixed in v0
 
 - Initial release
 
-[Unreleased]: https://github.com/japaric/cortex-m-rtfm/compare/v0.4.3...HEAD
-[v0.4.3]: https://github.com/japaric/cortex-m-rtfm/compare/v0.4.2...v0.4.3
-[v0.4.2]: https://github.com/japaric/cortex-m-rtfm/compare/v0.4.1...v0.4.2
-[v0.4.1]: https://github.com/japaric/cortex-m-rtfm/compare/v0.4.0...v0.4.1
-[v0.4.0]: https://github.com/japaric/cortex-m-rtfm/compare/v0.3.4...v0.4.0
-[v0.3.4]: https://github.com/japaric/cortex-m-rtfm/compare/v0.3.3...v0.3.4
-[v0.3.3]: https://github.com/japaric/cortex-m-rtfm/compare/v0.3.2...v0.3.3
-[v0.3.2]: https://github.com/japaric/cortex-m-rtfm/compare/v0.3.1...v0.3.2
-[v0.3.1]: https://github.com/japaric/cortex-m-rtfm/compare/v0.3.0...v0.3.1
-[v0.3.0]: https://github.com/japaric/cortex-m-rtfm/compare/v0.2.2...v0.3.0
-[v0.2.2]: https://github.com/japaric/cortex-m-rtfm/compare/v0.2.1...v0.2.2
-[v0.2.1]: https://github.com/japaric/cortex-m-rtfm/compare/v0.2.0...v0.2.1
-[v0.2.0]: https://github.com/japaric/cortex-m-rtfm/compare/v0.1.1...v0.2.0
-[v0.1.1]: https://github.com/japaric/cortex-m-rtfm/compare/v0.1.0...v0.1.1
+[Unreleased]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.4.3...HEAD
+[v0.4.3]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.4.2...v0.4.3
+[v0.4.2]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.4.1...v0.4.2
+[v0.4.1]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.4.0...v0.4.1
+[v0.4.0]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.3.4...v0.4.0
+[v0.3.4]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.3.3...v0.3.4
+[v0.3.3]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.3.2...v0.3.3
+[v0.3.2]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.3.1...v0.3.2
+[v0.3.1]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.3.0...v0.3.1
+[v0.3.0]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.2.2...v0.3.0
+[v0.2.2]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.2.1...v0.2.2
+[v0.2.1]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.2.0...v0.2.1
+[v0.2.0]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.1.1...v0.2.0
+[v0.1.1]: https://github.com/rtfm-rs/cortex-m-rtfm/compare/v0.1.0...v0.1.1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 authors = [
+  "The Real Time For the Masses developers",
   "Jorge Aparicio <jorge@japaric.io>",
   "Per Lindgren <per.lindgren@ltu.se>",
 ]
@@ -47,8 +48,8 @@ required-features = ["__v7"]
 
 [dependencies]
 cortex-m = "0.6.0"
-cortex-m-rtfm-macros = { path = "macros" }
-rtfm-core = "0.3.0-beta.1"
+cortex-m-rtfm-macros = { path = "macros", version = "0.5.0-beta.1" }
+rtfm-core = "0.3.0-beta.2"
 cortex-m-rt = "0.6.9"
 heapless = "0.5.0"
 

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2017-2018 Jorge Aparicio
+Copyright (c) 2017-2019 The Real Time For the Masses developers
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated

--- a/book/en/src/by-example.md
+++ b/book/en/src/by-example.md
@@ -7,7 +7,7 @@ All examples in this part of the book can be found in the GitHub [repository] of
 the project, and most of the examples can be run on QEMU so no special hardware
 is required to follow along.
 
-[repository]: https://github.com/japaric/cortex-m-rtfm
+[repository]: https://github.com/rtfm-rs/cortex-m-rtfm
 
 To run the examples on your laptop / PC you'll need the `qemu-system-arm`
 program. Check [the embedded Rust book] for instructions on how to set up an

--- a/book/en/src/by-example/new.md
+++ b/book/en/src/by-example/new.md
@@ -48,7 +48,7 @@ Here I'll use the `init` example from the `cortex-m-rtfm` crate.
 
 ``` console
 $ curl \
-    -L https://github.com/japaric/cortex-m-rtfm/raw/v0.5.0-alpha.1/examples/init.rs \
+    -L https://github.com/rtfm-rs/cortex-m-rtfm/raw/v0.5.0-beta.1/examples/init.rs \
     > src/main.rs
 ```
 

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -4,7 +4,7 @@ main() {
     # these are not needed for doc builds
     if [ $TRAVIS_BRANCH != master ] || [ $TRAVIS_PULL_REQUEST != false ]; then
         if [ $TARGET = x86_64-unknown-linux-gnu ]; then
-            ( cd .. && cargo install microamp-tools --version 0.1.0-alpha.2 -f )
+            ( cd .. && cargo install microamp-tools --version 0.1.0-alpha.3 -f )
             rustup target add thumbv6m-none-eabi thumbv7m-none-eabi
         fi
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
-authors = ["Jorge Aparicio <jorge@japaric.io>"]
+authors = [
+  "The Real Time For the Masses developers",
+  "Jorge Aparicio <jorge@japaric.io>",
+]
 categories = ["concurrency", "embedded", "no-std"]
 description = "Procedural macros of the cortex-m-rtfm crate"
 documentation = "https://rtfm-rs.github.io/cortex-m-rtfm/api/cortex_m_rtfm"
@@ -9,7 +12,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-rtfm-macros"
 readme = "../README.md"
 repository = "https://github.com/rtfm-rs/cortex-m-rtfm"
-version = "0.5.0-alpha.1"
+version = "0.5.0-beta.1"
 
 [lib]
 proc-macro = true
@@ -18,7 +21,7 @@ proc-macro = true
 proc-macro2 = "1"
 quote = "1"
 syn = "1"
-rtfm-syntax = "0.4.0-beta.1"
+rtfm-syntax = "0.4.0-beta.2"
 
 [features]
 heterogeneous = []


### PR DESCRIPTION
this updates all the remaining references to japaric/cortex-m-rtfm, the Cargo metadata and copyright notice. After this PR the crates will be ready for beta release.