### PR TITLE
more monotonic timer docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## v0.5.0 - 2019-09-?? (currently in beta pre-release)
+## v0.5.0 - 2019-??-?? (currently in beta pre-release)
 
 ### Added
 
@@ -45,7 +45,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   Cargo features are enabled.
 
 - [breaking-change][] the monotonic timer used to implement the `schedule` API
-  is now user configurable via the `#[app(monotonic = ..)]` argument.
+  is now user configurable via the `#[app(monotonic = ..)]` argument. IMPORTANT:
+  it is now the responsibility of the application author to configure and
+  initialize the chosen `monotonic` timer during the `#[init]` phase.
 
 - [breaking-change][] the `peripherals` field is not include in `init::Context`
   by default. One must opt-in using the `#[app(peripherals = ..)]` argument.

--- a/book/en/src/by-example/timer-queue.md
+++ b/book/en/src/by-example/timer-queue.md
@@ -34,6 +34,10 @@ first appear in the `schedule` argument of the context attribute. When
 scheduling a task the (user-defined) `Instant` at which the task should be
 executed must be passed as the first argument of the `schedule` invocation.
 
+Additionally, the chosen `monotonic` timer must be configured and initialized
+during the `#[init]** phase. Note that this is *also* the case if you choose to
+use the `CYCCNT` provided by the `cortex-m-rtfm` crate.
+
 The example below schedules two tasks from `init`: `foo` and `bar`. `foo` is
 scheduled to run 8 million clock cycles in the future. Next, `bar` is scheduled
 to run 4 million clock cycles in the future. Thus `bar` runs before `foo` since

--- a/book/en/src/by-example/timer-queue.md
+++ b/book/en/src/by-example/timer-queue.md
@@ -35,7 +35,7 @@ scheduling a task the (user-defined) `Instant` at which the task should be
 executed must be passed as the first argument of the `schedule` invocation.
 
 Additionally, the chosen `monotonic` timer must be configured and initialized
-during the `#[init]** phase. Note that this is *also* the case if you choose to
+during the `#[init]` phase. Note that this is *also* the case if you choose to
 use the `CYCCNT` provided by the `cortex-m-rtfm` crate.
 
 The example below schedules two tasks from `init`: `foo` and `bar`. `foo` is

--- a/examples/baseline.rs
+++ b/examples/baseline.rs
@@ -14,6 +14,8 @@ use panic_semihosting as _;
 const APP: () = {
     #[init(spawn = [foo])]
     fn init(cx: init::Context) {
+        // omitted: initialization of `CYCCNT`
+
         hprintln!("init(baseline = {:?})", cx.start).unwrap();
 
         // `foo` inherits the baseline of `init`: `Instant(0)`

--- a/examples/periodic.rs
+++ b/examples/periodic.rs
@@ -16,6 +16,8 @@ const PERIOD: u32 = 8_000_000;
 const APP: () = {
     #[init(schedule = [foo])]
     fn init(cx: init::Context) {
+        // omitted: initialization of `CYCCNT`
+
         cx.schedule.foo(Instant::now() + PERIOD.cycles()).unwrap();
     }
 

--- a/src/cyccnt.rs
+++ b/src/cyccnt.rs
@@ -3,9 +3,7 @@
 use core::{
     cmp::Ordering,
     convert::{Infallible, TryInto},
-    fmt,
-    marker::PhantomData,
-    ops,
+    fmt, ops,
 };
 
 use cortex_m::peripheral::DWT;
@@ -28,19 +26,13 @@ use crate::Fraction;
 #[derive(Clone, Copy, Eq, PartialEq)]
 pub struct Instant {
     inner: i32,
-    _not_send_or_sync: PhantomData<*mut ()>,
 }
-
-unsafe impl Sync for Instant {}
-
-unsafe impl Send for Instant {}
 
 impl Instant {
     /// Returns an instant corresponding to "now"
     pub fn now() -> Self {
         Instant {
             inner: DWT::get_cycle_count() as i32,
-            _not_send_or_sync: PhantomData,
         }
     }
 
@@ -222,9 +214,6 @@ impl crate::Monotonic for CYCCNT {
     }
 
     fn zero() -> Instant {
-        Instant {
-            inner: 0,
-            _not_send_or_sync: PhantomData,
-        }
+        Instant { inner: 0 }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,9 +138,21 @@ pub trait Monotonic {
     fn ratio() -> Fraction;
 
     /// Returns the current time
+    ///
+    /// # Correctness
+    ///
+    /// This function is *allowed* to return nonsensical values if called before `reset` is invoked
+    /// by the runtime. Therefore application authors should *not* call this function during the
+    /// `#[init]` phase.
     fn now() -> Self::Instant;
 
     /// Resets the counter to *zero*
+    ///
+    /// # Safety
+    ///
+    /// This function will be called *exactly once* by the RTFM runtime after `#[init]` returns and
+    /// before tasks can start; this is also the case in multi-core applications. User code must
+    /// *never* call this function.
     unsafe fn reset();
 
     /// A `Self::Instant` that represents a count of *zero*


### PR DESCRIPTION
covers

- initialization and configuration of the timer; this is now a responsibility of
  the application author
- correctness of `Monotonic::now()` in `#[init]`
- safety of `Monotonic::reset()`

closes #251
cc @jonas-schievink

(EDIT: yay, pull request number 0xFF)