### PR TITLE
[v0.4.x] CI: do not build docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,8 +49,6 @@ branches:
     - master
     - staging
     - trying
-    # to build docs
-    - v0.4.x
 
 notifications:
   email:


### PR DESCRIPTION
The docs for the v0.4.x releases are now being built and uploaded by the master
branch

addresses #262