### PR TITLE
CI: build 0.4 docs from the v0.4.x branch

### DIFF
--- a/ci/after-success.sh
+++ b/ci/after-success.sh
@@ -3,7 +3,7 @@ set -euxo pipefail
 main() {
     local langs=( en ru )
     local latest=0.5
-    local vers=( 0.4.3 )
+    local vers=( 0.4.x )
 
     rm -f .cargo/config
     cargo doc


### PR DESCRIPTION
instead of using a specific tag; this way documentation changes done to the
v0.4.x branch will show up on the site as soon as they land -- right now they
require publishing a new v0.4.x release on crates.io