### PR TITLE
CI: replace compiletest-rs with trybuild

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -8,6 +8,3 @@ runner = "qemu-system-arm -cpu cortex-m3 -machine lm3s6965evb -nographic -semiho
 rustflags = [
   "-C", "link-arg=-Tlink.x",
 ]
-
-[build]
-target = "thumbv7m-none-eabi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,7 @@ matrix:
 
       # compile-fail tests
     - env: TARGET=x86_64-unknown-linux-gnu
-      # FIXME revert this -- compiletest-rs v0.3.25 is broken with recent nightly
-      rust: nightly-2019-10-31
+      rust: nightly
       if: (branch = staging OR branch = trying) OR (type = pull_request AND branch = master)
 
       # heterogeneous multi-core support

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ features = ["exit"]
 version = "0.5.2"
 
 [target.x86_64-unknown-linux-gnu.dev-dependencies]
-compiletest_rs = "0.3.22"
+trybuild = "1"
 
 [features]
 heterogeneous = ["cortex-m-rtfm-macros/heterogeneous", "microamp"]

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -37,8 +37,11 @@ main() {
     mkdir -p ci/builds
 
     if [ $T = x86_64-unknown-linux-gnu ]; then
-        # compile-fail tests
-        cargo test --test single --target $T
+        if [ $TRAVIS_RUST_VERSION == 1.*.* ]; then
+            # test on a fixed version (MSRV) to avoid problems with changes in rustc diagnostics
+            # compile-fail tests
+            cargo test --test single --target $T
+        fi
 
         if [ $TRAVIS_RUST_VERSION = nightly ]; then
             # multi-core compile-pass tests

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -37,10 +37,10 @@ main() {
     mkdir -p ci/builds
 
     if [ $T = x86_64-unknown-linux-gnu ]; then
-        if [ $TRAVIS_RUST_VERSION = nightly ]; then
-            # compile-fail tests
-            cargo test --test single --target $T
+        # compile-fail tests
+        cargo test --test single --target $T
 
+        if [ $TRAVIS_RUST_VERSION = nightly ]; then
             # multi-core compile-pass tests
             pushd heterogeneous
             local exs=(

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -37,7 +37,7 @@ main() {
     mkdir -p ci/builds
 
     if [ $T = x86_64-unknown-linux-gnu ]; then
-        if [ $TRAVIS_RUST_VERSION == 1.*.* ]; then
+        if [[ $TRAVIS_RUST_VERSION == 1.*.* ]]; then
             # test on a fixed version (MSRV) to avoid problems with changes in rustc diagnostics
             # compile-fail tests
             cargo test --test single --target $T

--- a/tests/single.rs
+++ b/tests/single.rs
@@ -1,19 +1,7 @@
-use std::path::PathBuf;
-
-use compiletest_rs::{common::Mode, Config};
+use trybuild::TestCases;
 
 #[test]
 fn ui() {
-    let mut config = Config::default();
-
-    config.mode = Mode::Ui;
-    config.src_base = PathBuf::from("ui/single");
-    config.target_rustcflags = Some(
-        "--edition=2018 -L target/debug/deps -Z unstable-options --extern rtfm --extern lm3s6965"
-            .to_owned(),
-    );
-    config.link_deps();
-    config.clean_rmeta();
-
-    compiletest_rs::run_tests(&config);
+    let t = TestCases::new();
+    t.compile_fail("ui/single/*.rs");
 }

--- a/ui/single/exception-invalid.stderr
+++ b/ui/single/exception-invalid.stderr
@@ -3,6 +3,3 @@ error: only exceptions with configurable priority can be used as hardware tasks
   |
 6 |     fn nmi(_: nmi::Context) {}
   |        ^^^
-
-error: aborting due to previous error
-

--- a/ui/single/exception-systick-used.stderr
+++ b/ui/single/exception-systick-used.stderr
@@ -3,6 +3,3 @@ error: this exception can't be used because it's being used by the runtime
   |
 6 |     fn sys_tick(_: sys_tick::Context) {}
   |        ^^^^^^^^
-
-error: aborting due to previous error
-

--- a/ui/single/extern-interrupt-not-enough.stderr
+++ b/ui/single/extern-interrupt-not-enough.stderr
@@ -3,6 +3,3 @@ error: not enough `extern` interrupts to dispatch all software tasks (need: 1; g
   |
 6 |     fn a(_: a::Context) {}
   |        ^
-
-error: aborting due to previous error
-

--- a/ui/single/extern-interrupt-used.stderr
+++ b/ui/single/extern-interrupt-used.stderr
@@ -3,6 +3,3 @@ error: `extern` interrupts can't be used as hardware tasks
   |
 5 |     #[task(binds = UART0)]
   |                    ^^^^^
-
-error: aborting due to previous error
-

--- a/ui/single/locals-cfg.stderr
+++ b/ui/single/locals-cfg.stderr
@@ -28,6 +28,10 @@ error[E0425]: cannot find value `FOO` in this scope
 44 |         FOO;
    |         ^^^ not found in this scope
 
-error: aborting due to 5 previous errors
+error: duplicate lang item in crate `panic_halt`: `panic_impl`.
+  |
+  = note: first defined in crate `std`.
 
-For more information about this error, try `rustc --explain E0425`.
+error: duplicate lang item in crate `panic_semihosting`: `panic_impl`.
+  |
+  = note: first defined in crate `panic_halt`.

--- a/ui/single/resources-cfg.stderr
+++ b/ui/single/resources-cfg.stderr
@@ -117,7 +117,3 @@ error[E0609]: no field `o5` on type `uart1Resources<'_>`
    |                     ^^ unknown field
    |
    = note: available fields are: `__marker__`
-
-error: aborting due to 15 previous errors
-
-For more information about this error, try `rustc --explain E0609`.

--- a/ui/single/task-priority-too-high.stderr
+++ b/ui/single/task-priority-too-high.stderr
@@ -4,7 +4,7 @@ warning: unused import: `rtfm::app`
 3 | use rtfm::app;
   |     ^^^^^^^^^
   |
-  = note: `#[warn(unused_imports)]` on by default
+  = note: #[warn(unused_imports)] on by default
 
 error[E0080]: evaluation of constant value failed
  --> $DIR/task-priority-too-high.rs:5:1

--- a/ui/single/task-priority-too-high.stderr
+++ b/ui/single/task-priority-too-high.stderr
@@ -1,9 +1,13 @@
+warning: unused import: `rtfm::app`
+ --> $DIR/task-priority-too-high.rs:3:5
+  |
+3 | use rtfm::app;
+  |     ^^^^^^^^^
+  |
+  = note: `#[warn(unused_imports)]` on by default
+
 error[E0080]: evaluation of constant value failed
  --> $DIR/task-priority-too-high.rs:5:1
   |
 5 | #[rtfm::app(device = lm3s6965)]
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ attempt to subtract with overflow
-
-error: aborting due to previous error
-
-For more information about this error, try `rustc --explain E0080`.


### PR DESCRIPTION
We use compiletest to run compile-fail tests but compiletest depends on compiler
internals so it breaks every now and then and requires nightly. With trybuild we
can also run compile-fail tests but it works on stable and it already has
reached version 1.0