### PR TITLE
[v0.4.x] CI: pin to an older nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,8 @@ matrix:
 
     # NOTE used to build docs on successful merges to master
     - env: TARGET=x86_64-unknown-linux-gnu
-      rust: nightly
+      # FIXME revert this -- compiletest-rs v0.3.25 is broken with recent nightly
+      rust: nightly-2019-10-31
 
     - env: TARGET=thumbv6m-none-eabi
       rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,7 @@ matrix:
 
     # NOTE used to build docs on successful merges to master
     - env: TARGET=x86_64-unknown-linux-gnu
-      # FIXME revert this -- compiletest-rs v0.3.25 is broken with recent nightly
-      rust: nightly-2019-10-31
+      rust: nightly
 
     - env: TARGET=thumbv6m-none-eabi
       rust: nightly

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,9 +1,12 @@
 set -euxo pipefail
 
 main() {
-    if [ $TARGET != x86_64-unknown-linux-gnu ]; then
-        rustup target add $TARGET
+    if [ $TARGET = x86_64-unknown-linux-gnu ]; then
+        # needed by compiletest-rs
+        rustup component add rustc-dev
     fi
+
+    rustup target add $TARGET
 
     mkdir qemu
     curl -L https://github.com/japaric/qemu-bin/raw/master/14.04/qemu-system-arm-2.12.0 > qemu/qemu-system-arm


### PR DESCRIPTION
to workaround compiletest-rs being broken on recent nightlies

this is a backport of #267 and it's required to land #265 

I'm not backporting #268  (compiletest -> trybuild) because this branch has compile-pass tests which depend on compiletest and can't be ported to trybuild