### PR TITLE
Cyccnt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## v0.5.1 - 2019-11-18
+- Fixed arithmetic wrapping bug in src/cyccntr.rs
+  elapsed and duration could cause an internal overflow trap
+  on subtraction in debug mode.
+
 ## v0.5.0 - 2019-11-14
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ license = "MIT OR Apache-2.0"
 name = "cortex-m-rtfm"
 readme = "README.md"
 repository = "https://github.com/rtfm-rs/cortex-m-rtfm"
-version = "0.5.0"
+version = "0.5.1"
 
 [lib]
 name = "rtfm"

--- a/src/cyccnt.rs
+++ b/src/cyccnt.rs
@@ -38,12 +38,14 @@ impl Instant {
 
     /// Returns the amount of time elapsed since this instant was created.
     pub fn elapsed(&self) -> Duration {
-        Instant::now() - *self
+        let diff = Instant::now().inner.wrapping_sub(self.inner);
+        assert!(diff >= 0, "instant now is earlier than self");
+        Duration { inner: diff as u32 }
     }
 
     /// Returns the amount of time elapsed from another instant to this one.
     pub fn duration_since(&self, earlier: Instant) -> Duration {
-        let diff = self.inner - earlier.inner;
+        let diff = self.inner.wrapping_sub(earlier.inner);
         assert!(diff >= 0, "second instant is later than self");
         Duration { inner: diff as u32 }
     }


### PR DESCRIPTION
The subtractions in `elapsed` and `duration` may cause an overflow panic in debug mode. This is solved by using wrapping arithmetics.  
