### PR TITLE
book, Russian lang: fix "idle not defined" typo

### DIFF
--- a/book/ru/src/by-example/app.md
+++ b/book/ru/src/by-example/app.md
@@ -63,7 +63,7 @@ $ cargo run --example init
 `init`, `idle` запустится *с включенными прерываниями* и не может завершиться,
 поэтому будет работать бесконечно.
 
-Когда функция `idle` определена, рантайм устанавливает бит [SLEEPONEXIT], после чего
+Когда функция `idle` не определена, рантайм устанавливает бит [SLEEPONEXIT], после чего
 отправляет микроконтроллер в состояние сна после выполнения `init`.
 
 [SLEEPONEXIT]: https://developer.arm.com/products/architecture/cpu-architecture/m-profile/docs/100737/0100/power-management/sleep-mode/sleep-on-exit-bit


### PR DESCRIPTION
Fix typo in Russian translation of book, was "When idle function is declared", should be "When no idle function is declared"

"не" means "not".

Corresponding text in English:

```markdown
When no `idle` function is declared, the runtime sets the [SLEEPONEXIT] bit and
then sends the microcontroller to sleep after running `init`.
```