### PR TITLE
Retain cfg-attributes on resources

### DIFF
--- a/examples/t-cfg-resources.rs
+++ b/examples/t-cfg-resources.rs
@@ -1,0 +1,40 @@
+//! [compile-pass] check that `#[cfg]` attributes applied on resources work
+//!
+#![no_main]
+#![no_std]
+
+use panic_halt as _;
+
+#[cfg(rustc_is_nightly)]
+mod example {
+
+    #[rtfm::app(device = lm3s6965)]
+    const APP: () = {
+        struct Resources {
+            // A resource
+            #[init(0)]
+            shared: u32,
+
+            // A conditionally compiled resource behind feature_x
+            #[cfg(feature = "feature_x")]
+            x: u32,
+
+            dummy: (),
+        }
+
+        #[init]
+        fn init(_: init::Context) -> init::LateResources {
+            init::LateResources {
+                // The feature needs to be applied everywhere x is defined or used
+                #[cfg(feature = "feature_x")]
+                x: 0,
+                dummy: () // dummy such that we have at least one late resource
+            }
+        }
+
+        #[idle]
+        fn idle(_cx: idle::Context) -> ! {
+            loop {}
+        }
+    };
+}

--- a/macros/src/codegen.rs
+++ b/macros/src/codegen.rs
@@ -39,7 +39,7 @@ pub fn app(app: &App, analysis: &Analysis, extra: &Extra) -> TokenStream2 {
         let (const_app_init, root_init, user_init, call_init) =
             init::codegen(core, app, analysis, extra);
 
-        let (const_app_post_init, post_init_stmts) = post_init::codegen(core, analysis, extra);
+        let (const_app_post_init, post_init_stmts) = post_init::codegen(core, &app, analysis, extra);
 
         let (const_app_idle, root_idle, user_idle, call_idle) =
             idle::codegen(core, app, analysis, extra);

--- a/macros/src/codegen/init.rs
+++ b/macros/src/codegen/init.rs
@@ -44,8 +44,12 @@ pub fn codegen(
                         .iter()
                         .map(|name| {
                             let ty = &app.late_resources[name].ty;
+                            let cfgs = &app.late_resources[name].cfgs;
 
-                            quote!(pub #name: #ty)
+                            quote!(
+                                #(#cfgs)*
+                                pub #name: #ty
+                                )
                         })
                         .collect::<Vec<_>>()
                 })

--- a/macros/src/codegen/resources.rs
+++ b/macros/src/codegen/resources.rs
@@ -101,9 +101,15 @@ pub fn codegen(
             ));
 
             let ptr = if expr.is_none() {
-                quote!(#name.as_mut_ptr())
+                quote!(
+                    #(#cfgs)*
+                    #name.as_mut_ptr()
+                )
             } else {
-                quote!(&mut #name)
+                quote!(
+                    #(#cfgs)*
+                    &mut #name
+                )
             };
 
             const_app.push(util::impl_mutex(


### PR DESCRIPTION
When rust 1.43 lands as stable this will resolve #301 and allow for the kind of conditional compilation exemplified in the issue.

Tested on beta and nightly.