### PR TITLE
Use build.rs for conditional compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ rtfm-core = "0.3.0"
 cortex-m-rt = "0.6.9"
 heapless = "0.5.0"
 
+[build-dependencies]
+version_check = "0.9"
+
 [dependencies.microamp]
 optional = true
 version = "0.1.0-alpha.2"

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,12 @@
 use std::env;
+use version_check;
 
 fn main() {
     let target = env::var("TARGET").unwrap();
+
+    if version_check::Channel::read().unwrap().is_nightly() {
+        println!("cargo:rustc-cfg=rustc_is_nightly")
+    }
 
     if target.starts_with("thumbv6m") {
         println!("cargo:rustc-cfg=armv6m")

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -46,7 +46,6 @@ main() {
         if [ $TRAVIS_RUST_VERSION = nightly ]; then
             # Tests where required MSRV > 1.36
             local exs=(
-                t-cfg-resources
             )
             for ex in ${exs[@]}; do
                 cargo check --example $ex --target $T

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -44,6 +44,14 @@ main() {
         fi
 
         if [ $TRAVIS_RUST_VERSION = nightly ]; then
+            # Tests where required MSRV > 1.36
+            local exs=(
+                t-cfg-resources
+            )
+            for ex in ${exs[@]}; do
+                cargo check --example $ex --target $T
+            done
+
             # multi-core compile-pass tests
             pushd heterogeneous
             local exs=(

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -45,11 +45,11 @@ main() {
 
         if [ $TRAVIS_RUST_VERSION = nightly ]; then
             # Tests where required MSRV > 1.36
-            local exs=(
-            )
-            for ex in ${exs[@]}; do
-                cargo check --example $ex --target $T
-            done
+            #local exs=(
+            #)
+            #for ex in ${exs[@]}; do
+            #    cargo check --example $ex --target $T
+            #done
 
             # multi-core compile-pass tests
             pushd heterogeneous


### PR DESCRIPTION
Extend the current test suite to allow for running tests on newer rustc-versions than current MSRV.

Required by #306 to add special tests for future MSRV.

To exclude an example from the regular non-nightly testing:

```
#![no_main]
#![no_std]

#[cfg(rustc_is_nightly)]
mod example {

    use panic_halt as _;

    #[rtfm::app(device = lm3s6965)]
    const APP: () = {
    <more code>
    }
}
```