### PR TITLE
Update example to use better initial value

### DIFF
--- a/examples/periodic.rs
+++ b/examples/periodic.rs
@@ -18,7 +18,7 @@ const APP: () = {
     fn init(cx: init::Context) {
         // omitted: initialization of `CYCCNT`
 
-        cx.schedule.foo(Instant::now() + PERIOD.cycles()).unwrap();
+        cx.schedule.foo(cx.start + PERIOD.cycles()).unwrap();
     }
 
     #[task(schedule = [foo])]


### PR DESCRIPTION
The example above this in the documentation states

```
        // semantically, the monotonic timer is frozen at time "zero" during `init`
        // NOTE do *not* call `Instant::now` in this context; it will return a nonsense value
        let now = cx.start; // the start time of the system
```

It results in weird scheduling issues, but still eventually works.  `cx.start` is much more reliable.

Relates to https://github.com/rtfm-rs/cortex-m-rtfm/issues/196