### PR TITLE
allow handlers to be named 'main'

### DIFF
--- a/examples/t-htask-main.rs
+++ b/examples/t-htask-main.rs
@@ -1,0 +1,20 @@
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_semihosting::debug;
+use panic_semihosting as _;
+
+#[rtfm::app(device = lm3s6965)]
+const APP: () = {
+    #[init]
+    fn init(_: init::Context) {
+        rtfm::pend(lm3s6965::Interrupt::UART0)
+    }
+
+    #[task(binds = UART0)]
+    fn main(_: main::Context) {
+        debug::exit(debug::EXIT_SUCCESS);
+    }
+};

--- a/examples/t-idle-main.rs
+++ b/examples/t-idle-main.rs
@@ -1,0 +1,20 @@
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_semihosting::debug;
+use panic_semihosting as _;
+
+#[rtfm::app(device = lm3s6965)]
+const APP: () = {
+    #[init]
+    fn init(_: init::Context) {
+    }
+
+    #[idle]
+    fn main(_: main::Context) -> ! {
+        debug::exit(debug::EXIT_SUCCESS);
+        loop {}
+    }
+};

--- a/examples/t-init-main.rs
+++ b/examples/t-init-main.rs
@@ -1,0 +1,15 @@
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_semihosting::debug;
+use panic_semihosting as _;
+
+#[rtfm::app(device = lm3s6965)]
+const APP: () = {
+    #[init]
+    fn main(_: main::Context) {
+        debug::exit(debug::EXIT_SUCCESS);
+    }
+};

--- a/examples/t-stask-main.rs
+++ b/examples/t-stask-main.rs
@@ -1,0 +1,24 @@
+#![deny(unsafe_code)]
+#![deny(warnings)]
+#![no_main]
+#![no_std]
+
+use cortex_m_semihosting::debug;
+use panic_semihosting as _;
+
+#[rtfm::app(device = lm3s6965)]
+const APP: () = {
+    #[init(spawn = [main])]
+    fn init(cx: init::Context) {
+        cx.spawn.main().ok();
+    }
+
+    #[task]
+    fn main(_: main::Context) {
+        debug::exit(debug::EXIT_SUCCESS);
+    }
+
+    extern "C" {
+        fn UART0();
+    }
+};

--- a/macros/src/codegen/dispatchers.rs
+++ b/macros/src/codegen/dispatchers.rs
@@ -141,7 +141,7 @@ pub fn codegen(app: &App, analysis: &Analysis, extra: &Extra) -> Vec<TokenStream
                                 #let_instant
                                 #fq.split().0.enqueue_unchecked(index);
                                 let priority = &rtfm::export::Priority::new(PRIORITY);
-                                #name(
+                                crate::#name(
                                     #locals_new
                                     #name::Context::new(priority #instant)
                                     #(,#pats)*

--- a/macros/src/codegen/idle.rs
+++ b/macros/src/codegen/idle.rs
@@ -72,7 +72,7 @@ pub fn codegen(
         ));
 
         let locals_new = locals_new.iter();
-        let call_idle = quote!(#name(
+        let call_idle = quote!(crate::#name(
             #(#locals_new,)*
             #name::Context::new(&rtfm::export::Priority::new(0))
         ));

--- a/macros/src/codegen/init.rs
+++ b/macros/src/codegen/init.rs
@@ -105,7 +105,7 @@ pub fn codegen(
 
         let locals_new = locals_new.iter();
         let call_init =
-            Some(quote!(let late = #name(#(#locals_new,)* #name::Context::new(core.into()));));
+            Some(quote!(let late = crate::#name(#(#locals_new,)* #name::Context::new(core.into()));));
 
         root_init.push(module::codegen(Context::Init(core), needs_lt, app, extra));
 


### PR DESCRIPTION
`#[init]`, `#[idle]` and `#[task]` handlers can now be named `main`

fixes #311