### PR TITLE
Use cargo feature instead of conditional compilation hacks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           use-cross: false
           command: check
-          args: --examples --target=${{ matrix.target }}
+          args: --examples --target=${{ matrix.target }} --features __min_r1_43
 
       - name: cargo check -p homogeneous
         uses: actions-rs/cargo@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,10 @@ name = "t-cfg"
 required-features = ["__v7"]
 
 [[example]]
+name = "t-cfg-resources"
+required-features = ["__min_r1_43"]
+
+[[example]]
 name = "t-schedule"
 required-features = ["__v7"]
 
@@ -77,6 +81,7 @@ heterogeneous = ["cortex-m-rtfm-macros/heterogeneous", "microamp"]
 homogeneous = ["cortex-m-rtfm-macros/homogeneous"]
 # used for testing this crate; do not use in applications
 __v7 =[]
+__min_r1_43 =[]
 
 [profile.release]
 codegen-units = 1

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -96,8 +96,18 @@ main() {
 
     if [ $TARGET = thumbv6m-none-eabi ]; then
         cargo check --target $T --examples
+
+        # Check examples with specific features not compatible with MSRV
+        if [[ $TRAVIS_RUST_VERSION != 1.*.* ]]; then
+            cargo check --target $T --examples --features __min_r1_43
+        fi
     else
         cargo check --target $T --examples --features __v7
+
+        # Check examples with specific features not compatible with MSRV
+        if [[ $TRAVIS_RUST_VERSION != 1.*.* ]]; then
+            cargo check --target $T --examples --features __v7,__min_r1_43
+        fi
     fi
 
     cargo check -p homogeneous --target $T --examples

--- a/examples/t-cfg-resources.rs
+++ b/examples/t-cfg-resources.rs
@@ -5,36 +5,32 @@
 
 use panic_halt as _;
 
-#[cfg(rustc_is_nightly)]
-mod example {
+#[rtfm::app(device = lm3s6965)]
+const APP: () = {
+    struct Resources {
+        // A resource
+        #[init(0)]
+        shared: u32,
 
-    #[rtfm::app(device = lm3s6965)]
-    const APP: () = {
-        struct Resources {
-            // A resource
-            #[init(0)]
-            shared: u32,
+        // A conditionally compiled resource behind feature_x
+        #[cfg(feature = "feature_x")]
+        x: u32,
 
-            // A conditionally compiled resource behind feature_x
+        dummy: (),
+    }
+
+    #[init]
+    fn init(_: init::Context) -> init::LateResources {
+        init::LateResources {
+            // The feature needs to be applied everywhere x is defined or used
             #[cfg(feature = "feature_x")]
-            x: u32,
-
-            dummy: (),
+            x: 0,
+            dummy: (), // dummy such that we have at least one late resource
         }
+    }
 
-        #[init]
-        fn init(_: init::Context) -> init::LateResources {
-            init::LateResources {
-                // The feature needs to be applied everywhere x is defined or used
-                #[cfg(feature = "feature_x")]
-                x: 0,
-                dummy: (), // dummy such that we have at least one late resource
-            }
-        }
-
-        #[idle]
-        fn idle(_cx: idle::Context) -> ! {
-            loop {}
-        }
-    };
-}
+    #[idle]
+    fn idle(_cx: idle::Context) -> ! {
+        loop {}
+    }
+};


### PR DESCRIPTION
As noted by japaric, using cargo features to do selective testing is cleaner than cfg-hacks.

Introduce new testing-feature indicating this test requires at minimum Rust v1.43.

Modify both test-suites to handle the new feature and remove the cfg-hack from the example.