### PR TITLE
No build opt on msrv

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,6 +59,10 @@ jobs:
           target: ${{ matrix.target }}
           override: true
 
+      - name: Disable optimisation profiles
+        if: matrix.toolchain == '1.36.0'
+        run: sed -i '/^\[profile.*build-override]$/,/^$/{/^#/!{/^$/!d}}' Cargo.toml
+
       - name: cargo check
         uses: actions-rs/cargo@v1
         with:
@@ -268,6 +272,11 @@ jobs:
           toolchain: ${{ matrix.toolchain }}
           target: ${{ matrix.target }}
           override: true
+
+      - name: Disable optimisation profiles
+        if: matrix.toolchain == '1.36.0'
+        run: sed -i '/^\[profile.*build-override]$/,/^$/{/^#/!{/^$/!d}}' Cargo.toml
+
       - name: cargo check
         uses: actions-rs/cargo@v1
         with:
@@ -287,6 +296,10 @@ jobs:
           toolchain: 1.36.0
           target: thumbv7m-none-eabi
           override: true
+
+      - name: Disable optimisation profiles
+        run: sed -i '/^\[profile.*build-override]$/,/^$/{/^#/!{/^$/!d}}' Cargo.toml
+
       - uses: actions-rs/cargo@v1
         with:
           use-cross: false
@@ -305,6 +318,10 @@ jobs:
           toolchain: 1.36.0
           target: thumbv6m-none-eabi
           override: true
+
+      - name: Disable optimisation profiles
+        run: sed -i '/^\[profile.*build-override]$/,/^$/{/^#/!{/^$/!d}}' Cargo.toml
+
       - uses: actions-rs/cargo@v1
         with:
           use-cross: false

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -36,6 +36,12 @@ main() {
 
     mkdir -p ci/builds
 
+    # Current MSRV cannot handle profiles, remove compilation optimisations
+    if [[ $TRAVIS_RUST_VERSION == 1.*.* ]]; then
+        echo "Removing optimisation profiles"
+        sed -i '/^\[profile.*build-override]$/,/^$/{/^#/!{/^$/!d}}' Cargo.toml
+    fi
+
     if [ $T = x86_64-unknown-linux-gnu ]; then
         if [[ $TRAVIS_RUST_VERSION == 1.*.* ]]; then
             # test on a fixed version (MSRV) to avoid problems with changes in rustc diagnostics


### PR DESCRIPTION
#314 is failing the tests since 1.36.0 is not capable of 'build-override' profiles.

This extends current CI setup for both Travis and GHA to remove any `build-override` before running in case toolchain is 1.36.0.